### PR TITLE
fixes layout bug when leaving maximized window state #7

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,6 @@
   </head>
   <body>
     <style>
-
       html
       {
         user-select: unset; 
@@ -17,8 +16,7 @@
       {
         display: none;
       }
-
     </style>
-    <periodic-table></periodic-table>
+    <periodic-table id="periodic-table"></periodic-table>
   </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,4 +1,5 @@
 const electron = require('electron');
+const debounce = require('lodash.debounce')
 
 const app = electron.app;
 const BrowserWindow = electron.BrowserWindow;
@@ -9,107 +10,132 @@ const Menu = electron.Menu;
 
 const path = require('path');
 
-let browserWindow = null;
+let window = null;
 
-function createWindow()
-{
-  browserWindow = new BrowserWindow(
-  {
+function createWindow() {
+  window = new BrowserWindow({
     width: 800,
     height: 545,
     backgroundColor: '#fff'
   });
+  window.loadURL(path.join('file://', __dirname, 'index.html'));
 
-  browserWindow.loadURL(path.join('file://', __dirname, 'index.html'));
+  function forceRedraw() {
+    window.webContents.executeJavaScript(
+      `document.getElementById('periodic-table').style.display = 'none';`);
 
-  browserWindow.on('closed', () =>
-  {
-    browserWindow = null;
+    setTimeout(() => {
+      window.webContents.executeJavaScript(
+        `document.getElementById('periodic-table').style.display = '';
+        document.getElementsByTagName('body')[0].style.filter = '';`);
+    }, 20);
+  }
+
+  let isRedrawApplied = true;
+  const debouncedRedraw = debounce(() => {
+    isRedrawApplied = true;
+    forceRedraw();
+  }, 200);
+
+  window.on('maximize', () => {
+    isRedrawApplied = false;
+  });
+
+  window.on('move', () => {
+    if (!window.isMaximized() && !isRedrawApplied) {
+      window.webContents.executeJavaScript(
+        `document.getElementsByTagName('body')[0].style.filter = 'blur(5px)';`);
+      debouncedRedraw();
+    }
+  });
+
+  window.on('closed', () => {
+    window = null;
   });
 
   const template =
-  [
-    {
-      label: 'Edit',
-      submenu: [
-        {role: 'undo'},
-        {role: 'redo'},
-        {type: 'separator'},
-        {role: 'cut'},
-        {role: 'copy'},
-        {role: 'paste'},
-        {role: 'pasteandmatchstyle'},
-        {role: 'delete'},
-        {role: 'selectall'}
-      ]
-    },
-    {
-      label: 'View',
-      submenu: [
-        {role: 'reload'},
-        {role: 'forcereload'},
-        {role: 'toggledevtools'},
-        {type: 'separator'},
-        {role: 'resetzoom'},
-        {role: 'zoomin'},
-        {role: 'zoomout'},
-        {type: 'separator'},
-        {role: 'togglefullscreen'}
-      ]
-    },
-    {
-      role: 'window',
-      submenu: [
-        {role: 'minimize'},
-        {role: 'close'}
-      ]
-    },
-    {
-      role: 'help',
-      submenu: [
-        {
-          label: 'Learn More',
-          click () { require('electron').shell.openExternal('https://github.com/FlorianFe/Elements') }
-        }
-      ]
-    }
-  ]
+    [
+      {
+        label: 'Edit',
+        submenu: [
+          { role: 'undo' },
+          { role: 'redo' },
+          { type: 'separator' },
+          { role: 'cut' },
+          { role: 'copy' },
+          { role: 'paste' },
+          { role: 'pasteandmatchstyle' },
+          { role: 'delete' },
+          { role: 'selectall' }
+        ]
+      },
+      {
+        label: 'View',
+        submenu: [
+          { role: 'reload' },
+          { role: 'forcereload' },
+          { role: 'toggledevtools' },
+          { type: 'separator' },
+          { role: 'resetzoom' },
+          { role: 'zoomin' },
+          { role: 'zoomout' },
+          { type: 'separator' },
+          { role: 'togglefullscreen' }
+        ]
+      },
+      {
+        role: 'window',
+        submenu: [
+          { role: 'minimize' },
+          { role: 'close' }
+        ]
+      },
+      {
+        role: 'help',
+        submenu: [
+          {
+            label: 'Learn More',
+            click() { require('electron').shell.openExternal('https://github.com/FlorianFe/Elements') }
+          }
+        ]
+      }
+    ]
 
   if (process.platform === 'darwin') {
     template.unshift({
       label: app.getName(),
       submenu: [
-        {role: 'about'},
-        {type: 'separator'},
-        {role: 'services', submenu: []},
-        {type: 'separator'},
-        {role: 'hide'},
-        {role: 'hideothers'},
-        {role: 'unhide'},
-        {type: 'separator'},
-        {role: 'quit'}
+        { role: 'about' },
+        { type: 'separator' },
+        { role: 'services', submenu: [] },
+        { type: 'separator' },
+        { role: 'hide' },
+        { role: 'hideothers' },
+        { role: 'unhide' },
+        { type: 'separator' },
+        { role: 'quit' }
       ]
     })
 
     // Edit menu
     template[1].submenu.push(
-      {type: 'separator'},
+      { type: 'separator' },
       {
         label: 'Speech',
         submenu: [
-          {role: 'startspeaking'},
-          {role: 'stopspeaking'}
+          { role: 'startspeaking' },
+          { role: 'stopspeaking' }
         ]
       }
     )
 
     // Window menu
     template[3].submenu = [
-      {role: 'close'},
-      {role: 'minimize'},
-      {role: 'zoom'},
-      {type: 'separator'},
-      {role: 'front'}
+      { role: 'close' },
+      { role: 'minimize' },
+      { role: 'zoom' },
+      { type: 'separator' },
+      { role: 'front' }
     ]
   }
 
@@ -118,23 +144,18 @@ function createWindow()
 }
 
 
-app.on('ready', () =>
-{
+app.on('ready', () => {
   createWindow();
 });
 
-app.on('activate', function ()
-{
-  if (browserWindow === null)
-  {
+app.on('activate', function () {
+  if (window === null) {
     createWindow()
   }
 });
 
-app.on('window-all-closed', () =>
-{
-  if(process.platform !== 'darwin')
-  {
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
     app.quit()
   }
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "Elements",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1430,6 +1430,11 @@
         "p-locate": "^3.0.0",
         "path-exists": "^3.0.0"
       }
+    },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
     },
     "loggly": {
       "version": "0.3.11",

--- a/package.json
+++ b/package.json
@@ -16,13 +16,15 @@
     },
     "win": {
       "icon": "build/icon"
-    }, 
-    "linux":{
-      "target": ["deb", "AppImage"], 
+    },
+    "linux": {
+      "target": [
+        "deb",
+        "AppImage"
+      ],
       "icon": "build/icons/",
-      "desktop": 
-      {
-        "Name": "Elements", 
+      "desktop": {
+        "Name": "Elements",
         "Comment": "An application which displays the periodic table",
         "Categories": "Science;Chemistry;"
       }
@@ -34,8 +36,7 @@
     "polymer",
     "electron"
   ],
-  "author": 
-  {
+  "author": {
     "name": "Florian Fechner",
     "email": "f_fech03@uni-muenster.de",
     "url": "https://github.com/FlorianFe"
@@ -48,6 +49,7 @@
   "dependencies": {
     "electron-localshortcut": "^3.1.0",
     "ipc": "0.0.1",
+    "lodash.debounce": "^4.0.8",
     "path": "^0.12.7"
   }
 }


### PR DESCRIPTION
Changing a maximized window to normal state fires 'move' and 'unmaximize' (not used) events. In that moment a redraw and reflow of the web document is forced so that the responsive layout is recalculated and applied properly. This is done via hiding and - after a delay - showing the root element. The move event is also continuously fired when dragging the window around. Since this event fires so often, constantly redrawing the page with 'show/hide' results in distracting flickering. Therefore it is saved in a variable if the window was maximized and not yet rerendered. The rerender is debounced to prevent the flickering. While in the window-still-dragging-state the window is already rendered blurred with the wrong fullscreen layout to give the user a feedback that a rerender has not yet happened and he has to release the drag to see the content